### PR TITLE
Experiment: support multiple transports (OAuth + HTTP Basic)

### DIFF
--- a/includes/services/core/oauth2.php
+++ b/includes/services/core/oauth2.php
@@ -197,12 +197,16 @@ class Keyring_Service_OAuth2 extends Keyring_Service_OAuth1 {
 		$token = $this->token ? $this->token : null;
 
 		if ( ! is_null( $token ) ) {
-			if ( $this->authorization_header ) {
-				// type can be OAuth, Bearer, ...
-				$params['headers']['Authorization'] = $this->authorization_header . ' ' . (string) $token;
-			} else {
-				$url = add_query_arg( array( $this->authorization_parameter => urlencode( (string) $token ) ), $url );
-			}
+            if ($this->token->is_http_basic()) {
+                $params['headers']['Authorization'] = 'Basic ' . $this->token->token;
+            } else {
+                if ($this->authorization_header) {
+                    // type can be OAuth, Bearer, ...
+                    $params['headers']['Authorization'] = $this->authorization_header . ' ' . (string)$token;
+                } else {
+                    $url = add_query_arg(array($this->authorization_parameter => urlencode((string)$token)), $url);
+                }
+            }
 		}
 
 		$raw_response = false;

--- a/includes/services/extended/0-google-base.php
+++ b/includes/services/extended/0-google-base.php
@@ -253,6 +253,9 @@ class Keyring_Service_GoogleBase extends Keyring_Service_OAuth2 {
 		echo '</p>';
 		echo '</form>';
 		echo '</div>';
+		if($this->supports_basic_auth){
+		    $this->http_basic_auth_ui();
+        }
 	}
 
 	function test_connection() {

--- a/includes/services/extended/google-mail.php
+++ b/includes/services/extended/google-mail.php
@@ -16,6 +16,7 @@ class Keyring_Service_GoogleMail extends Keyring_Service_GoogleBase {
 
 	function __construct() {
 		parent::__construct();
+		$this->supports_basic_auth = true;
 	}
 
 	function _get_credentials() {

--- a/includes/services/extended/twitter.php
+++ b/includes/services/extended/twitter.php
@@ -17,6 +17,7 @@ class Keyring_Service_Twitter extends Keyring_Service_OAuth1 {
 			add_filter( 'keyring_twitter_basic_ui_intro', array( $this, 'basic_ui_intro' ) );
 		}
 
+		$this->supports_basic_auth = true;
 		$this->authorization_header = true;
 		$this->authorization_realm  = 'twitter.com';
 

--- a/token.php
+++ b/token.php
@@ -114,6 +114,11 @@ class Keyring_Token {
 		// Not expired
 		return false;
 	}
+
+    function is_http_basic()
+    {
+        return (bool)$this->get_meta('basic');
+    }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR is about HTTP Basic requests support in OAuth1 and OAuth2 services in addition to OAuth requests. 
The main idea is to store both access tokens: for OAuth 1/2 and HTTP Basic. There is no need to do request and verify token logic as in the deprecated `Keyring_Service_HTTP_Basic` service. The token for basic auth would be saved in manage UI.
Changes are not affecting old implementations unless `$supports_basic_auth` attribute in base service is set to `true`.

In order to do that, next changes were necessary:
- Add `$supports_basic_auth` to `service.php`, make it `false` by default;
- Add the following logic when `$supports_basic_auth` is `true`: show username/password form on manage service page. Save the token if username/password is set, add `basic = 1` in the token meta;
- Add `is_http_basic()` method to `token.php` that returns `true`, if there is `basic = 1` in token meta;
- Modify `request()` functions in `OAuth1` and `OAuth2` services if there is an attempt to make a request with basic access token `$token->is_http_basic()`.

## Usage

In order to make request using basic access token, you must set it to the service, see twitter example below:
```
$service = Keyring::get_service_by_name('twitter');

$service->set_token( $basic_token );

$user = $service->request('http://httpbin.org/basic-auth/user/passwd');
wp_send_json_success([
	'user' => $user
]);
```
You can still make requests to twitter using OAuth token:
```
$service = Keyring::get_service_by_name('twitter');

$service->set_token( $oauth_token );

$picture = $service->request('https://api.twitter.com/1.1/account/verify_credentials.json');
wp_send_json_success([
	'pic' => $picture
]);
```

## How it looks like

### Manage UI
Manage UI for OAuth1 (e.g. Twitter) service with `$supports_basic_auth = true`
![image](https://user-images.githubusercontent.com/79862886/115196252-63b3e680-a0f8-11eb-86b1-57ac7f8b5191.png)

Manage UI for OAuth2 (e.g. Google Mail) service with `$supports_basic_auth = true`
![image](https://user-images.githubusercontent.com/79862886/115196678-dde46b00-a0f8-11eb-90ca-37b76cc85c05.png)

### Access tokens list

Multiple access tokens for OAuth1 (e.g. Twitter) service with `$supports_basic_auth = true`
![image](https://user-images.githubusercontent.com/79862886/115196412-89d98680-a0f8-11eb-8788-ebd31892cae0.png)

Multiple access tokens for OAuth2 (e.g. Google Mail) service with `$supports_basic_auth = true`
![image](https://user-images.githubusercontent.com/79862886/115196562-b7becb00-a0f8-11eb-8224-9cd83911b8b6.png)

### Making API calls with different tokens

Get twitter account info using OAuth1 access token
![image](https://user-images.githubusercontent.com/79862886/115196949-2a2fab00-a0f9-11eb-8201-39a7a99487ff.png)

Get user info with HTTP Basic access token
![image](https://user-images.githubusercontent.com/79862886/115196975-3287e600-a0f9-11eb-9fef-489236e12788.png)
